### PR TITLE
Prepare repository for official release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,29 @@
-language: scala
-script: sbt ";testOnly io.gatling.amqp.PublishingSimulation; testOnly io.gatling.amqp.ConsumingSimulation"
 sudo: false
+
+language: scala
+
+scala:
+  - 2.12.7
+
+jdk:
+  - oraclejdk8
+
+branches:
+  only:
+    - master
+
+before_cache:
+  # Cleanup the cached directories to avoid unnecessary cache updates
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test
+
 services:
  - rabbitmq

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current libraries version
 - scala 2.12.6 (no support for scala 2.11.x)
 - amqp-client-4.9.0
 - gatling-2.3.1
-- gatling-sbt-2.2.2 (wit depdency to `SBT` 1.2.3)
+- gatling-sbt-2.2.2 (whit dependency to `SBT` [1.2.3))
 
 Usage
 =====

--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,19 @@
 import sbt.ExclusionRule
+import ReleaseTransformations._
 
 cancelable in Global := true
 
 enablePlugins(GatlingPlugin)
 
-scalaVersion := "2.12.6"
-
+organization  := "io.github.dieselr"
+name          := "gatling-amqp"
+description   := "Gatling AMQP library extension"
+homepage      := Some(url("https://github.com/dieselr/gatling-amqp"))
+licenses      := Seq("MIT License" -> url("http://www.opensource.org/licenses/mit-license.php"))
 scalacOptions := Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",
-  "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps")
-
-val gatlingVersion = "2.3.1"
-
-version := "0.11.0-SNAPSHOT"
-organization := "sc.ala"
-name := "gatling-amqp"
-description := "Gatling AMQP support"
-homepage := Some(url("https://github.com/dieselr/gatling-amqp"))
-licenses := Seq("MIT License" -> url("http://www.opensource.org/licenses/mit-license.php"))
+  "-feature", "-unchecked", "-language:implicitConversions", "-language:postfixOps"
+)
 
 developers              := List(
   Developer(
@@ -28,13 +24,52 @@ developers              := List(
   ),
   Developer(
     id    = "dieselr",
-    name  = "Diesel R",
+    name  = "DieselR",
     email = "dieselr@gmail.com",
     url   = url("https://github.com/dieselr")
   )
 )
 
+useGpg := true
+pgpSecretRing := pgpPublicRing.value
+
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/dieselr/gatling-amqp"),
+    "scm:git@github.com:dieselr/gatling-amqp.git"
+  )
+)
+
+pomIncludeRepository := { _ => false }
+publishTo := sonatypePublishTo.value
+publishMavenStyle := true
+
+publishConfiguration := publishConfiguration.value.withOverwrite(isSnapshot.value)
+com.typesafe.sbt.pgp.PgpKeys.publishSignedConfiguration := com.typesafe.sbt.pgp.PgpKeys.publishSignedConfiguration.value.withOverwrite(isSnapshot.value)
+publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(isSnapshot.value)
+com.typesafe.sbt.pgp.PgpKeys.publishLocalSignedConfiguration := com.typesafe.sbt.pgp.PgpKeys.publishLocalSignedConfiguration.value.withOverwrite(isSnapshot.value)
+
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
+releaseTagName := s"${if (releaseUseGlobalVersion.value) (version in ThisBuild).value else version.value}"
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  releaseStepCommand(s"""sonatypeOpen "${organization.value}" "${name.value}""""),
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  releaseStepCommand("publishSigned"),
+  setNextVersion,
+  commitNextVersion,
+  releaseStepCommand("publishSigned"),
+//  releaseStepCommand("sonatypeReleaseAll"),
+)
+
 (Test / test) := ((Test / test) dependsOn(Gatling / test)).value
+
+val gatlingVersion = "2.3.1"
 
 libraryDependencies += "io.gatling.highcharts"    % "gatling-charts-highcharts"   % gatlingVersion    % Compile
 libraryDependencies += "io.gatling"               % "gatling-test-framework"      % gatlingVersion    % Compile

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
-//addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
-//addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
-
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.3")

--- a/src/main/scala/io/gatling/amqp/action/AmqpPublishAction.scala
+++ b/src/main/scala/io/gatling/amqp/action/AmqpPublishAction.scala
@@ -41,6 +41,7 @@ class AmqpPublishAction(attributes: AmqpAttributes[PublishRequest], val statsEng
   private def publishMessage(session: Session)(postAction: (PublishRequest, Long) => Unit): Validation[Unit] = {
     val startDate = nowMillis
     attributes.payload(session).map { req =>
+      logger.debug(s"Content payload used for enqueueing is [${new String(req.bytes, "UTF-8")}]")
       amqpProtocol.router ! AmqpPublishRequest(req, session)
       postAction(req, startDate)
     }

--- a/src/test/scala/io/gatling/amqp/SubscriberSimulation.scala
+++ b/src/test/scala/io/gatling/amqp/SubscriberSimulation.scala
@@ -7,7 +7,7 @@ import io.gatling.core.Predef._
 
 import scala.concurrent.duration._
 
-class ConsumingSimulation extends Simulation {
+class SubscriberSimulation extends Simulation {
   implicit val amqpProtocol: AmqpProtocol = amqp
     .host("localhost")
     .port(5672)

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.11.0-SNAPSHOT"


### PR DESCRIPTION
Configure `SBT` for official release using command `publish`.
Added new plugins:

* sbt-pgp - to sign artifact
* sbt-sonatype - to publish into https://central.sonatype.org/ public
  repository
* sbt-release - make release automatically

New travis extensive configurations.